### PR TITLE
Fixing ion-refresher tumbnail refresh error

### DIFF
--- a/src/pages/list2/list2.html
+++ b/src/pages/list2/list2.html
@@ -12,10 +12,10 @@
       <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
   
-  <ion-list>
+  <ion-list [virtualScroll]="newlistDTFB">
 
-  <ion-item *ngFor="let tournament of newlistDTFB">
-      <ion-thumbnail item-left>  
+  <ion-item  *virtualItem="let tournament">
+      <ion-thumbnail item-left>
           <ion-img src="assets/imgs/test.png"></ion-img>
       </ion-thumbnail>
       <h2>{{ tournament.name }}</h2>


### PR DESCRIPTION
fix for https://forum.ionicframework.com/t/ion-refresher-does-not-refresh-thumbnails-correctly/110988

Read: https://ionicframework.com/docs/api/components/img/Img/

```Note: ion-img is only meant to be used inside of virtual-scroll```

Therefor, if we use virtual-scroll, we fix it :) You see a really small jump in images, because it needs to reload the image.

If you don't want to use virtual-scroll: replace `<ion-img>` with `<img>`